### PR TITLE
✨ spec-to-issues-plugin v2.1.0: 関数単位Task（4階層目）の分解を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ d-market-git は Claude Code プラグインのマーケットプレイスリポ
 
 - `plugins/git-workflow-plugin/` - Git 操作支援（コミット・PR 作成・レビュー・ブランチ保護）
 - `plugins/workflow-automation-plugin/` - ワークフロー自動化（CI エラー修正・レビュー指摘修正・類似コード検出）
-- `plugins/spec-to-issues-plugin/` - 仕様書から GitHub Issue 自動生成（Epic→Issue→Sub-issue の 3 階層）
+- `plugins/spec-to-issues-plugin/` - 仕様書から GitHub Issue 自動生成（Epic→Issue→Sub-issue→Task の最大 4 階層。分解の深さは実行時に選択）
 - `.claude-plugin/marketplace.json` - プラグインレジストリ
 
 各プラグインは `plugin.json` を持ち、skills・agents・hooks で構成される。

--- a/plugins/spec-to-issues-plugin/agents/issues-creator-agent.md
+++ b/plugins/spec-to-issues-plugin/agents/issues-creator-agent.md
@@ -1,6 +1,6 @@
 ---
 name: issues-creator-agent
-description: "Issue分解計画ファイル（${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md）からGitHub Issueを自動作成するエージェント。計画ファイルをパースしてEpic・Issue・Sub-issueを起票し、親子リンクと依存関係を設定します。\n\n使用例:\n- \"Issueを作成して\"\n- \"分解計画からIssue作って\"\n- \"issues-plan.mdから起票して\"\n- \"Issue起票して\""
+description: "Issue分解計画ファイル（${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md）からGitHub Issueを自動作成するエージェント。計画ファイルをパースしてEpic・Issue・Sub-issue（必要に応じてTask）を起票し、親子リンクと依存関係を設定します。\n\n使用例:\n- \"Issueを作成して\"\n- \"分解計画からIssue作って\"\n- \"issues-plan.mdから起票して\"\n- \"Issue起票して\""
 color: orange
 ---
 
@@ -36,28 +36,39 @@ color: orange
 
    - `addSubIssue` で各IssueとSub-issueを紐付け
 
-7. **完了サマリーの報告**:
+7. **Task作成（4階層モードのみ）**:
 
-   - 作成した全Issue・Sub-issueの一覧を表示
+   - `##### Tasks` を持つ Sub-issue について Task を起票
+   - Task のタイトルは親 Sub-issue のプレフィックスを引き継ぎ、`type:task` ラベルを付与
+   - 計画に Task がなければこの Step と次の Step をスキップ
+
+8. **親子リンク設定（Sub-issue ← Task）**:
+
+   - `addSubIssue` で各 Sub-issue と Task を紐付け（4階層モードのみ）
+
+9. **完了サマリーの報告**:
+
+   - 作成した全Issue・Sub-issue・Taskの一覧を表示
    - リンク状態と依存関係を確認して報告
 
 ワークフロー：
 
 1. 「`${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md` を読み込みます...」
-2. 「Epic: 1件、Issue: {n}件、Sub-issue: {m}件を検出しました」
+2. 「Epic: 1件、Issue: {n}件、Sub-issue: {m}件、Task: {t}件を検出しました」
 3. 「この内容でIssueを作成してもよろしいですか？」
 4. 「Epic Issueを作成しました: #{number}」
 5. 「Issueを作成中... ({current}/{total})」
 6. 「Sub-issueを作成中... ({current}/{total})」
-7. 「親子リンクを設定中...」
-8. 「完了しました。作成されたIssue: [サマリー]」
+7. 「Taskを作成中... ({current}/{total})」（4階層モードのみ）
+8. 「親子リンクを設定中...」
+9. 「完了しました。作成されたIssue: [サマリー]」
 
 常に日本語で応答してください。
 
 ## **タスク管理ルール**
 
 - 承認後、作成に着手する前に全タスクをTaskCreateで作成する
-- タスクは1 Issue = 1タスク + Sub-issue一括 + リンク設定で管理
+- タスクは1 Issue = 1タスク + Sub-issue一括 + Task一括（4階層モード）+ リンク設定で管理
 - `activeForm`を必ず設定する
 - 作成開始時: `TaskUpdate`で`status: "in_progress"`に更新
 - 作成完了後: `TaskUpdate`で`status: "completed"`に更新

--- a/plugins/spec-to-issues-plugin/agents/spec-analyzer-agent.md
+++ b/plugins/spec-to-issues-plugin/agents/spec-analyzer-agent.md
@@ -1,6 +1,6 @@
 ---
 name: spec-analyzer-agent
-description: "仕様書・設計書MDファイルを解析してIssue分解計画ファイルを生成するエージェント。MDファイルを読み込み、Epic・Issue・Sub-issueの3階層に分解し、依存関係を含む計画を `${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md` に書き出します。\n\n使用例:\n- \"仕様書を分析して\"\n- \"Issue分解計画を作って\"\n- \"specを解析して\"\n- \"このMDからIssue計画を作って\""
+description: "仕様書・設計書MDファイルを解析してIssue分解計画ファイルを生成するエージェント。MDファイルを読み込み、Epic・Issue・Sub-issue（必要に応じてTask）の最大4階層に分解し、依存関係を含む計画を `${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md` に書き出します。\n\n使用例:\n- \"仕様書を分析して\"\n- \"Issue分解計画を作って\"\n- \"specを解析して\"\n- \"このMDからIssue計画を作って\""
 color: green
 ---
 
@@ -18,14 +18,21 @@ color: green
    - H2 → Issue候補、H3 → Sub-issue候補として分類
    - Issue間の依存関係を分析
 
-3. **分解計画の作成と書き出し**:
+3. **分解の深さの選択**:
 
-   - Epic + Issue + Sub-issueの3階層分解計画を作成
+   - `AskUserQuestion` でユーザーに分解の深さを確認する（SKILL.md Part 1 Step 2.5 参照）
+     - **標準（3階層）**: Epic → Issue → Sub-issue（従来どおり）
+     - **詳細（4階層）**: Sub-issue の下に Task（関数単位の極小タスク）を追加
+   - 「詳細」選択時は、H4以下や関数レベルの記述から関数単位で着手できる作業を Task として洗い出す
+
+4. **分解計画の作成と書き出し**:
+
+   - Epic + Issue + Sub-issue（詳細選択時は Task も）の分解計画を作成
    - Issue間の依存関係（blocked_by）を明示
    - プロジェクトルートの `${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md` に書き出し
    - スキルの出力フォーマットに従う
 
-4. **ユーザーへの報告**:
+5. **ユーザーへの報告**:
 
    - 作成した分解計画の概要を報告
    - 「内容を確認・編集した後、Issue作成エージェントで起票できます」と案内
@@ -54,8 +61,9 @@ color: green
 3. 「`${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/config.yml` を生成しました。」
 4. 「MDファイルを読み込みます...」
 5. 「ドキュメント構造を解析しています...」
-6. 「3階層の分解計画を作成しています...」
-7. 「`${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md` に書き出しました。内容を確認してください。」
+6. 「分解の深さを確認します（3階層 / 4階層）...」
+7. 「分解計画を作成しています...」
+8. 「`${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md` に書き出しました。内容を確認してください。」
 
 常に日本語で応答してください。
 

--- a/plugins/spec-to-issues-plugin/plugin.json
+++ b/plugins/spec-to-issues-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-to-issues-plugin",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "仕様書からGitHub Issueを自動生成するプラグイン（分析エージェント + 作成エージェントの2段階構成）",
   "author": {
     "name": "DIO0550"

--- a/plugins/spec-to-issues-plugin/scripts/create-github-labels.sh
+++ b/plugins/spec-to-issues-plugin/scripts/create-github-labels.sh
@@ -100,6 +100,7 @@ type:migration,D97706,マイグレーション/移行
 type:chore,6B7280,雑務/設定
 type:test,059669,テスト関連
 type:docs,8B5CF6,ドキュメント関連
+type:task,C5DEF5,関数単位の極小タスク
 
 # 領域
 area:frontend,EC4899,フロントエンド領域

--- a/plugins/spec-to-issues-plugin/skills/issue-template/SKILL.md
+++ b/plugins/spec-to-issues-plugin/skills/issue-template/SKILL.md
@@ -42,7 +42,7 @@ argument-hint: [プロジェクトパス（省略時はカレント）]
 
 以下を確認する（全項目スキップ可能。スキップ時はデフォルト値を使用）:
 
-1. **Issueタイプ**: デフォルト6種（Feature, Bug, Migration, Test, Docs, Chore）で十分か、追加・削除したいタイプがあるか
+1. **Issueタイプ**: デフォルト7種（Feature, Bug, Migration, Test, Docs, Chore, Task）で十分か、追加・削除したいタイプがあるか（`task` は4階層分解で使う関数単位の極小タスク用）
 2. **タイトルフォーマット**: デフォルトの `[Type] subject` 形式でよいか
 3. **ラベル体系**: 種別・エリア・優先度・サイズのラベル名をカスタマイズしたいか
 4. **本文セクション**: タイプ別の必須/任意セクションを変更したいか
@@ -124,5 +124,6 @@ rules:
 - 独自タイプの追加も可能（`name`, `label`, `description`, `body_sections` を定義）
 - ラベルのキーワードはプロジェクトの技術スタックに合わせて調整
 - `body_sections` の `required: true/false` でIssue作成時の必須チェックを制御
+- `task` タイプは `spec-to-issues` の4階層分解（Epic→Issue→Sub-issue→Task）で使う関数単位の極小タスク用。4階層分解を使わない場合は無視してよい
 
 デフォルトテンプレートは `references/default-template.yml` を参照。

--- a/plugins/spec-to-issues-plugin/skills/issue-template/references/default-template.yml
+++ b/plugins/spec-to-issues-plugin/skills/issue-template/references/default-template.yml
@@ -11,6 +11,7 @@ title_formats:
   test: "[Test] {summary}"
   docs: "[Docs] {summary}"
   chore: "[Chore] {summary}"
+  task: "[Task][{area}] {summary}"
 
 # Epic設定
 epic:
@@ -213,6 +214,26 @@ types:
         required: false
         prompt: "この変更が影響するコンポーネントや機能を記載"
 
+  - name: task
+    label: "type:task"
+    description: "関数単位の極小タスク（Sub-issueの下に紐づく最小実装単位。1関数・1メソッド・1ヘルパー程度）"
+    detection_keywords:
+      - "関数"
+      - "メソッド"
+      - "ヘルパー"
+      - "ユーティリティ"
+      - "バリデーション"
+    body_sections:
+      - key: overview
+        title: "概要"
+        required: true
+        prompt: "この関数・極小単位で実装する内容を1〜2文で記載"
+      - key: tasks
+        title: "タスク"
+        required: false
+        format: "checklist"
+        prompt: "必要なら細目をチェックリスト形式で記載（関数1つなら省略可）"
+
 # ラベル体系
 labels:
   # 種別ラベル（typesのlabelフィールドで自動定義）
@@ -238,6 +259,9 @@ labels:
     - name: "type:chore"
       description: "雑務/設定"
       color: "EDEDED"
+    - name: "type:task"
+      description: "関数単位の極小タスク"
+      color: "C5DEF5"
 
   # エリアラベル
   area:
@@ -327,6 +351,9 @@ rules:
     max_days_per_sub_issue: 1
     min_sub_issues_per_issue: 1
     max_sub_issues_per_issue: 8
+    # Task（関数単位）は4階層分解を選択した場合のみ生成する極小単位
+    max_hours_per_task: 4
+    max_tasks_per_sub_issue: 6
 
   # 依存関係
   dependencies:

--- a/plugins/spec-to-issues-plugin/skills/spec-to-issues/SKILL.md
+++ b/plugins/spec-to-issues-plugin/skills/spec-to-issues/SKILL.md
@@ -3,7 +3,7 @@ name: spec-to-issues
 description: 仕様書・設計書からGitHub Issueを自動生成する。Epic・Issue・Sub-issueの3階層に分解し、依存関係を明示して起票。ユーザーが明示的に呼び出した場合のみ使用。
 user-invocable: true
 disable-model-invocation: true
-allowed-tools: Bash(gh *), Read, Write, Glob, Grep
+allowed-tools: Bash(gh *), Read, Write, Glob, Grep, AskUserQuestion
 argument-hint: [仕様書MDファイルパス]
 ---
 
@@ -11,6 +11,7 @@ argument-hint: [仕様書MDファイルパス]
 
 仕様書・設計書のMDファイルからGitHub Issueを自動生成するスキル。
 Epic → Issue → Sub-issue の3階層構成で、Issue間の依存関係を明示する。
+さらに必要に応じて Sub-issue の下に **Task（関数単位の極小タスク）** を加えた最大4階層に分解できる。分解の深さ（3階層 / 4階層）は解析時に `AskUserQuestion` でユーザーが選択する。
 
 2つのエージェントで分担して実行する:
 - **spec-analyzer-agent**: 仕様書を解析し `${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md` に分解計画を書き出す
@@ -52,9 +53,11 @@ Issue本文・タイトル・ラベルのフォーマットは以下の優先順
    ↓
 2. ユーザー設定の確認（${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/config.yml）
    ↓
-3. 3階層 + 依存関係の分解計画を作成
+3. 分解の深さを選択（AskUserQuestion: 3階層 / 4階層）
    ↓
-4. ${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md に書き出し
+4. 分解計画を作成（依存関係つき。4階層なら Task も含める）
+   ↓
+5. ${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md に書き出し
 ```
 
 ### Step 1: MDファイルの読み込みと解析
@@ -75,8 +78,8 @@ Issue本文・タイトル・ラベルのフォーマットは以下の優先順
 |:--|:--|
 | H1 | Epicのタイトルソース |
 | H2 | Issue候補（中粒度の作業単位） |
-| H3 | Sub-issue候補（細粒度のタスク） |
-| H4以下 | Sub-issueの本文に含める（独立Issueにしない） |
+| H3 | Sub-issue候補（細粒度・ファイル単位の作業） |
+| H4以下 | **3階層モード**: Sub-issueの本文に含める（独立Issueにしない）。**4階層モード**: Task候補（関数単位の極小タスク）として切り出す |
 
 **Issueタイプの判定ルール:**
 
@@ -93,6 +96,9 @@ Issue本文・タイトル・ラベルのフォーマットは以下の優先順
 - UI関連のStorybookも同様に、Feature Issueのタスクとして含める
 - 実装に伴う小規模リファクタリング（関数分割、命名変更、既存コードの整理等）はFeature Issueのタスクとして含める。大規模な技術移行（フレームワーク移行、スキーマ変更等）のみMigrationとして分離する
 - コード内ドキュメント（JSDoc、コメント、型定義の説明等）はFeature Issueに含める。独立したドキュメント（README、API仕様書、ユーザーガイド等）のみDocsとして分離する
+
+**4階層モードを選択した場合の例外:**
+上記のうち「関数1つの実装」「関数分割」「小さなヘルパー・ユーティリティ追加」「単一バリデーション関数」など、関数単位で独立して着手できる作業は、Feature/Sub-issueのチェックリストに埋め込まず **Task（`type:task`）** として切り出す。対応する単体テストはその実装 Task のタスク欄に含める。3階層モードでは従来どおりチェックリストに吸収する。
 
 **エリア判定キーワード:**
 
@@ -121,6 +127,7 @@ Issue本文・タイトル・ラベルのフォーマットは以下の優先順
 **分解の粒度ルール:**
 - Issue（中粒度）: 1-3日で完了可能な単位
 - Sub-issue（細粒度）: 半日〜1日で完了可能な単位
+- Task（極小粒度・**4階層モードのみ**）: 数時間（〜4時間）で完了可能な関数単位。1 Sub-issueあたり Task 2-6件が目安。これ以上に細かくはしない
 - 1 Issueあたり Sub-issue 2-5件が目安
 - 3日以上かかりそうなセクションは複数Issueに分割する
 
@@ -159,6 +166,22 @@ Issue本文・タイトル・ラベルのフォーマットは以下の優先順
 回答があった項目のみ `${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/config.yml` に書き出す。全スキップの場合は空のymlを生成する。
 
 設定スキーマの詳細は `references/config-schema.md` を参照。
+
+### Step 2.5: 分解の深さの選択
+
+分解計画を作る前に、`AskUserQuestion` でユーザーに分解の深さを確認する。
+
+**質問**: 「どの粒度まで分解しますか？」
+
+| 選択肢 | 内容 |
+|:--|:--|
+| **標準（3階層）** | Epic → Issue → Sub-issue。関数単位の作業は各Issue/Sub-issueのチェックリストに含める（従来の挙動） |
+| **詳細（4階層）** | 上記に加え、Sub-issue の下に **Task（関数単位の極小タスク）** を起票する |
+
+- **標準を選択**: 以降 Task は生成しない（従来どおりの出力。後方互換）
+- **詳細を選択**: 各 Sub-issue について、関数単位で独立して着手できる作業を Task として洗い出す（粒度ルール参照）。Task が自然に切り出せない Sub-issue は Task なしでよい（混在可）
+
+選択結果は `${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md` のフォーマット（Task セクションの有無）に反映する。
 
 ### Step 3: `${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md` への書き出し
 
@@ -201,6 +224,21 @@ Issue本文・タイトル・ラベルのフォーマットは以下の優先順
        ## タスク
        - [ ] タスク1
 
+   ##### Tasks
+   （4階層モードのみ。なければセクションごと省略）
+
+   1. {Taskタイトル}
+      - labels: type:task, {area}
+      - body: |
+          ## 概要
+          {関数単位で実装する内容}
+
+   2. {Taskタイトル}
+      - labels: type:task, {area}
+      - body: |
+          ## 概要
+          {関数単位で実装する内容}
+
 2. {Sub-issueタイトル}
    - labels: {label1}, {label2}
    - body: |
@@ -239,6 +277,7 @@ Issue本文・タイトル・ラベルのフォーマットは以下の優先順
 - `blocked_by`: 依存先Issueの連番リスト（`[]` は依存なし）
 - `body`: `|` の後にインデント付きでIssue本文（Markdown）
 - Sub-issuesは `#### Sub-issues` セクション内に番号付きリストで定義
+- Tasksは各Sub-issue配下の `##### Tasks` セクション内に番号付きリストで定義（4階層モードのみ。3階層モードでは出力しない）
 - 依存関係グラフは `#連番 → #連番` 形式
 
 ---
@@ -264,9 +303,13 @@ Issue本文・タイトル・ラベルのフォーマットは以下の優先順
    ↓
 8. Issue ← Sub-issue 親子リンク設定
    ↓
-9. Epic本文をIssue番号で更新
+9. Task作成（4階層モードのみ、各Sub-issueごと）
    ↓
-10. 完了サマリー報告
+10. Sub-issue ← Task 親子リンク設定（4階層モードのみ）
+   ↓
+11. Epic本文をIssue番号で更新
+   ↓
+12. 完了サマリー報告
 ```
 
 ### Step 1: `${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md` の読み込みとパース
@@ -276,6 +319,7 @@ Issue本文・タイトル・ラベルのフォーマットは以下の優先順
 - **Epic**: タイトル、ラベル
 - **Issues**: 各Issueのタイトル、ラベル、依存関係（blocked_by）、本文
 - **Sub-issues**: 各Issue配下のSub-issueタイトル、ラベル、本文
+- **Tasks**: 各Sub-issue配下のTaskタイトル、ラベル、本文（4階層モードのみ。存在しなければスキップ）
 - **依存関係グラフ**
 
 #### パースルール
@@ -285,6 +329,7 @@ Issue本文・タイトル・ラベルのフォーマットは以下の優先順
 - `- blocked_by: [{...}]` は数値配列としてパース（`[]` は依存なし）
 - `- body: |` の次行以降、インデントされた行がIssue本文
 - `#### Sub-issues` 以降の番号付きリストがSub-issue定義
+- `##### Tasks` 以降の番号付きリストがTask定義（各Sub-issue配下。セクションが無ければそのSub-issueにTaskなし）
 
 ### Step 2: ユーザー確認
 
@@ -400,7 +445,35 @@ gh api graphql -f query='
 ' -f parentId="{issue_node_id}" -f childId="{sub_issue_node_id}"
 ```
 
-### Step 9: Epic本文更新
+### Step 9: Task作成（4階層モードのみ）
+
+`${CLAUDE_PLUGIN_ROOT}/.plugin-workspace/issues/issues-plan.md` に `##### Tasks` セクションがある Sub-issue について、配下の Task を起票する。3階層モード（Task定義なし）ではこの Step と Step 10 をスキップする。
+
+タイトルは親 Sub-issue のプレフィックスを引き継ぐ。ラベルは `type:task` と継承エリアラベルを付与する。
+
+```bash
+TASK_URL=$(gh issue create \
+  --title "{sub_issue_prefix} - {task_title}" \
+  --body "{Task本文}" \
+  --label "type:task" --label "{area}")
+
+TASK_NUM=$(echo "$TASK_URL" | grep -oE '[0-9]+$')
+```
+
+### Step 10: Sub-issue ← Task 親子リンク設定（4階層モードのみ）
+
+```bash
+gh api graphql -f query='
+  mutation($parentId: ID!, $childId: ID!) {
+    addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) {
+      issue { id title }
+      subIssue { id title }
+    }
+  }
+' -f parentId="{sub_issue_node_id}" -f childId="{task_node_id}"
+```
+
+### Step 11: Epic本文更新
 
 全Issue作成後、Epicの「Issue一覧」を実番号で更新。
 
@@ -410,7 +483,7 @@ gh api graphql -f query='
 - [ ] #{issue_2} {タイトル} (Blocked by #{issue_1})
 ```
 
-### Step 10: 完了サマリー報告
+### Step 12: 完了サマリー報告
 
 ```
 ## Issue作成サマリー
@@ -418,13 +491,14 @@ gh api graphql -f query='
 ### Epic
 - #{epic_number} [Epic] {タイトル}
 
-### Issue（{n}件）+ Sub-issue（{m}件）
+### Issue（{n}件）+ Sub-issue（{m}件）+ Task（{t}件）
 - [x] #{issue_1} {タイトル} (Sub-issues: #{s1}, #{s2})
 - [x] #{issue_2} {タイトル} (Blocked by #{issue_1}) (Sub-issues: #{s3})
 
 ### リンク状態
 - 全 {n} 件のIssueがEpicにリンク済み
 - 全 {m} 件のSub-issueが各親Issueにリンク済み
+- 全 {t} 件のTaskが各親Sub-issueにリンク済み（4階層モードのみ）
 ```
 
 ---
@@ -445,6 +519,7 @@ bash plugins/spec-to-issues-plugin/scripts/create-github-labels.sh
 | 種別 | `type:chore` | 雑務/設定 |
 | 種別 | `type:test` | テスト関連 |
 | 種別 | `type:docs` | ドキュメント関連 |
+| 種別 | `type:task` | 関数単位の極小タスク（4階層モード） |
 | 領域 | `area:frontend` | フロントエンド |
 | 領域 | `area:server` | バックエンド/サーバ |
 | 領域 | `area:shared` | 共有/横断 |
@@ -473,6 +548,8 @@ bash plugins/spec-to-issues-plugin/scripts/create-github-labels.sh
 | GraphQL `addSubIssue`失敗 | 報告するが続行（手動リンクを案内） |
 | Issue数が20件超 | 作成前にユーザーに確認 |
 | Sub-issue数が多すぎる（1 Issueあたり8件超） | 粒度の再検討を提案 |
+| Task数が多すぎる（1 Sub-issueあたり6件超） | 4階層分解の粒度の再検討を提案 |
+| 4階層モードで総Issue数が過大（合計50件超） | 作成前に件数を提示してユーザーに確認 |
 
 ## 禁止事項
 


### PR DESCRIPTION
## 概要

`spec-to-issues-plugin` に、Sub-issue（≒ファイル単位）よりさらに小さい **Task（関数1つの極小単位）** を起票する4階層目を追加しました。

従来は「関数1つの実装・関数分割・命名変更」などは Feature Issue のチェックリスト項目に吸収され、独立した起票単位になりませんでした。本PRでこれを独立 Issue（`type:task`）として扱えるようにします。

## 分解構造

| 見出し | 階層 | 粒度 |
|:--|:--|:--|
| H1 | Epic | — |
| H2 | Issue | 1-3日 |
| H3 | Sub-issue（≒ファイル単位） | 半日〜1日 |
| H4以下・関数記述 | **Task（≒関数1つ）** | 数時間（選択時のみ） |

- 分解の深さ（**3階層 / 4階層**）は spec-analyzer 実行時に `AskUserQuestion` でユーザーが選択
- Task は GitHub の `addSubIssue` で Sub-issue の子としてネスト
- **「3階層（標準）」選択時は Task を一切出力せず、従来挙動を完全維持（後方互換）**

## 変更ファイル

- `skills/spec-to-issues/SKILL.md` — 見出し対応表・粒度ルール・Step 2.5（深さ選択）・`issues-plan.md` フォーマット・Part2 の Task 起票/リンク Step・サマリー・エラーハンドリング。`allowed-tools` に `AskUserQuestion` 追加
- `agents/spec-analyzer-agent.md` — 分解の深さ選択ステップ
- `agents/issues-creator-agent.md` — Task 起票・`Sub-issue ← Task` リンク手順
- `skills/issue-template/references/default-template.yml` — `task` タイプ・`type:task` ラベル・`max_hours_per_task`
- `skills/issue-template/SKILL.md` — デフォルト7種への言及
- `scripts/create-github-labels.sh` — `type:task` ラベル
- `plugin.json` — `2.0.0 → 2.1.0`
- `CLAUDE.md` — リポジトリ構成を最大4階層に更新

## 検証

- `DRY_RUN=1` でラベルスクリプトに `type:task` が作成対象として出ることを確認
- Part 2 の Step 番号が 1〜12 で連続し、`##### Tasks` フォーマットとパースルールが一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)